### PR TITLE
fix NullPointerException from empty Tools

### DIFF
--- a/src/main/java/com/sourceauditor/spdxcyclone/CycloneToSpdx.java
+++ b/src/main/java/com/sourceauditor/spdxcyclone/CycloneToSpdx.java
@@ -1140,29 +1140,32 @@ public class CycloneToSpdx {
         	retainFidelity(spdxDoc, "metadata.authors", metadata.getAuthors(), warnings);
         }
         boolean toolFidelity = false;
-        for (Tool tool:metadata.getTools()) {
-            StringBuilder sb = new StringBuilder("Tool: ");
-            String name = tool.getName();
-            String vendor = tool.getVendor();
-            String version = tool.getVersion();
-            if (Objects.nonNull(vendor)) {
-                sb.append(vendor);
-                sb.append(":");
-            }
-            if (Objects.nonNull(name)) {
-                sb.append(name);
-            } else {
-                sb.append("[UNKNOWN]");
-            }
-            if (Objects.nonNull(version)) {
-                sb.append("-");
-                sb.append(version);
-            }
-            creators.add(sb.toString());
-            if (Objects.nonNull(tool.getHashes()) && !tool.getHashes().isEmpty() ||
-            		Objects.nonNull(tool.getExtensibleTypes()) && !tool.getExtensibleTypes().isEmpty() ||
-            		Objects.nonNull(tool.getExtensions()) && !tool.getExtensions().isEmpty()) {
-            	toolFidelity = true;
+        final List<Tool> tools = metadata.getTools();
+        if (tools != null) {
+            for (Tool tool : tools) {
+                StringBuilder sb = new StringBuilder("Tool: ");
+                String name = tool.getName();
+                String vendor = tool.getVendor();
+                String version = tool.getVersion();
+                if (Objects.nonNull(vendor)) {
+                    sb.append(vendor);
+                    sb.append(":");
+                }
+                if (Objects.nonNull(name)) {
+                    sb.append(name);
+                } else {
+                    sb.append("[UNKNOWN]");
+                }
+                if (Objects.nonNull(version)) {
+                    sb.append("-");
+                    sb.append(version);
+                }
+                creators.add(sb.toString());
+                if (Objects.nonNull(tool.getHashes()) && !tool.getHashes().isEmpty() ||
+                        Objects.nonNull(tool.getExtensibleTypes()) && !tool.getExtensibleTypes().isEmpty() ||
+                        Objects.nonNull(tool.getExtensions()) && !tool.getExtensions().isEmpty()) {
+                    toolFidelity = true;
+                }
             }
         }
         if (toolFidelity) {


### PR DESCRIPTION
Using the test file below, I was getting a NPE due to a null from `metadata.getTools()`.

This PR attempts to guard against that case. (Pre-apologies for tab/space madness. Trying to go to space where possible.)

Could you point me to a good way to add a unit test for this case?

Here's the test file I used, but I'd like to add a test for this condition.

```json
{
  "bomFormat": "CycloneDX",
  "specVersion": "1.4",
  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
  "version": 1,
  "metadata": {
    "timestamp": "2022-02-21T17:20:41Z",
    "component": {
      "name": "Acme Application",
      "version": "9.1.1",
      "type": "application",
      "bom-ref": "acme-app"
    }
  },
  "components": [
    {
      "name": "acme-library",
      "version": "1.0.0",
      "hashes": [
        {
          "alg": "SHA-1",
          "content": "9188560f22e0b73070d2efce670c74af2bdf30af"
        },
        {
          "alg": "SHA-256",
          "content": "d88bc4e70bfb34d18b5542136639acbb26a8ae2429aa1e47489332fb389cc964"
        }
      ],
      "cpe": "cpe:/a:acme:application:9.1.1",
      "type": "library"
    },
    {
      "group": "com.fasterxml.jackson.core",
      "name": "jackson-databind",
      "version": "2.8.0",
      "licenses": [
        {
          "license": {
            "id": "Apache-2.0"
          }
        }
      ],
      "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.0?type=jar",
      "type": "library"
    }
  ],
  "dependencies": [
    {
      "ref": "acme-app",
      "dependsOn": [
        "pkg:maven/org.acme/web-framework@1.0.0?type=jar",
        "pkg:maven/org.acme/persistence@3.1.0?type=jar"
      ]
    },
    {
      "ref": "pkg:maven/org.acme/web-framework@1.0.0?type=jar",
      "dependsOn": [
        "pkg:maven/org.acme/common-util@3.0.0?type=jar"
      ]
    },
    {
      "ref": "pkg:maven/org.acme/persistence@3.1.0?type=jar",
      "dependsOn": [
        "pkg:maven/org.acme/common-util@3.0.0?type=jar"
      ]
    },
    {
      "ref": "pkg:maven/org.acme/common-util@3.0.0?type=jar",
      "dependsOn": []
    }
  ],
  "vulnerabilities": [
    {
      "id": "CVE-2018-7489",
      "source": {
        "name": "NVD",
        "url": "https://nvd.nist.gov/vuln/detail/CVE-2019-9997"
      },
      "ratings": [
        {
          "source": {
            "name": "NVD",
            "url": "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H&version=3.0"
          },
          "score": 9.8,
          "severity": "critical",
          "method": "CVSSv3",
          "vector": "AN/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
        }
      ],
      "cwes": [
        184,
        502
      ],
      "description": "FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath.",
      "recommendation": "Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.6.7.5, 2.8.11.1, 2.9.5 or higher.",
      "advisories": [
        {
          "title": "GitHub Commit",
          "url": "https://github.com/FasterXML/jackson-databind/commit/6799f8f10cc78e9af6d443ed6982d00a13f2e7d2"
        }
      ],
      "created": "2021-01-01T00:00:00Z",
      "published": "2021-01-01T00:00:00Z",
      "updated": "2021-01-01T00:00:00Z",
      "analysis": {
        "state": "not_affected",
        "justification": "code_not_reachable",
        "response": [
          "will_not_fix",
          "update"
        ],
        "detail": "An optional explanation of why the application is not affected by the vulnerable component."
      },
      "affects": [
        {
          "ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.8.0?type=jar"
        }
      ]
    }
  ]
}
```
